### PR TITLE
Initial Implementation of Email Sender via Mailgun API

### DIFF
--- a/Areas/EmailSender/MailgunOptions.cs
+++ b/Areas/EmailSender/MailgunOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace SIT.Controller.Areas.EmailSender
+{
+    public class MailgunOptions
+    {
+        public string? ApiKey { get; set; }
+        public string? Domain { get; set; }
+    }
+}

--- a/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
+++ b/Areas/Identity/Pages/Account/ConfirmEmail.cshtml
@@ -4,5 +4,20 @@
     ViewData["Title"] = "Confirm email";
 }
 
-<h1>@ViewData["Title"]</h1>
-<partial name="_StatusMessage" model="Model.StatusMessage" />
+<h1 style="margin-top: 10vh !important">@ViewData["Title"]</h1>
+<div class="mt-5 centered-div">
+    <partial name="_StatusMessage" model="Model.StatusMessage" />
+</div>
+
+<style>
+    .centered-div {
+        color: #fff;
+        padding: 20px;
+        border-radius: 10px;
+        margin-top: 10vh !important;
+        max-width: 60%;
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+    }
+</style>

--- a/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/Areas/Identity/Pages/Account/ConfirmEmail.cshtml.cs
@@ -44,7 +44,7 @@ namespace SIT.Controller.Areas.Identity.Pages.Account
 
             code = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(code));
             var result = await _userManager.ConfirmEmailAsync(user, code);
-            StatusMessage = result.Succeeded ? "Thank you for confirming your email." : "Error confirming your email.";
+            StatusMessage = result.Succeeded ? "Your account has been successfully verified. You can now log in and start using your new account." : "Error confirming your email.";
             return Page();
         }
     }

--- a/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
+using SIT.Controller.Components.Account;
 using SIT.Controller.Controllers;
 
 namespace SIT.Controller.Areas.Identity.Pages.Account
@@ -29,15 +30,15 @@ namespace SIT.Controller.Areas.Identity.Pages.Account
         private readonly IUserStore<IdentityUser> _userStore;
         private readonly IUserEmailStore<IdentityUser> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
-        private readonly IEmailSender _emailSender;
         private readonly RegistrationStateService _registrationStateService;
+        private readonly IEmailSender<IdentityUser> _emailSender;
 
         public RegisterModel(
             UserManager<IdentityUser> userManager,
             IUserStore<IdentityUser> userStore,
             SignInManager<IdentityUser> signInManager,
             ILogger<RegisterModel> logger,
-            IEmailSender emailSender,
+            IEmailSender<IdentityUser> emailSender,
             RegistrationStateService registrationStateService)
         {
             _userManager = userManager;
@@ -110,7 +111,7 @@ namespace SIT.Controller.Areas.Identity.Pages.Account
                 {
                     _logger.LogInformation("User created a new account with password.");
 
-                    // Assign the "User" role to the new user
+                    // Assigning the "User" role to the new user
                     await _userManager.AddToRoleAsync(user, "User");
 
                     var userId = await _userManager.GetUserIdAsync(user);
@@ -122,8 +123,7 @@ namespace SIT.Controller.Areas.Identity.Pages.Account
                         values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
                         protocol: Request.Scheme);
 
-                    await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
-                        $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+                    await _emailSender.SendConfirmationLinkAsync(user, Input.Email, callbackUrl);
 
                     if (_userManager.Options.SignIn.RequireConfirmedAccount)
                     {

--- a/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -1,0 +1,23 @@
+﻿@page
+@model RegisterConfirmationModel
+@{
+    ViewData["Title"] = "Register confirmation";
+}
+
+<h1>@ViewData["Title"]</h1>
+@{
+    if (@Model.DisplayConfirmAccountLink)
+    {
+<p>
+    This app does not currently have a real email sender registered, see <a href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
+    Normally this would be emailed: <a id="confirm-link" href="@Model.EmailConfirmationUrl">Click here to confirm your account</a>
+</p>
+    }
+    else
+    {
+<p>
+        Please check your email to confirm your account.
+</p>
+    }
+}
+

--- a/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -4,20 +4,37 @@
     ViewData["Title"] = "Register confirmation";
 }
 
-<h1>@ViewData["Title"]</h1>
-@{
-    if (@Model.DisplayConfirmAccountLink)
-    {
-<p>
-    This app does not currently have a real email sender registered, see <a href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
-    Normally this would be emailed: <a id="confirm-link" href="@Model.EmailConfirmationUrl">Click here to confirm your account</a>
-</p>
+<h1 style="margin-top: 10vh !important">@ViewData["Title"]</h1>
+<div class="mt-5 centered-div">
+    @{
+        if (@Model.DisplayConfirmAccountLink)
+        {
+            <p>
+                This app does not currently have set email sender registered and configured.
+                <br>
+                <hr>
+                <a id="confirm-link" href="@Model.EmailConfirmationUrl">Click here to confirm your account</a>
+            </p>
+        }
+        else
+        {
+            <p>
+                Please check your email to confirm your account.
+            </p>
+        }
     }
-    else
-    {
-<p>
-        Please check your email to confirm your account.
-</p>
-    }
-}
+</div>
 
+<style>
+    .centered-div {
+        background-color: #333;
+        color: #fff;
+        padding: 20px;
+        border-radius: 10px;
+        margin-top: 20vh !important;
+        max-width: 60%;
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+    }
+</style>

--- a/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+#nullable disable
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace SIT.Controller.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class RegisterConfirmationModel : PageModel
+    {
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly IEmailSender _sender;
+
+        public RegisterConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender sender)
+        {
+            _userManager = userManager;
+            _sender = sender;
+        }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public bool DisplayConfirmAccountLink { get; set; }
+
+        /// <summary>
+        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public string EmailConfirmationUrl { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(string email, string returnUrl = null)
+        {
+            if (email == null)
+            {
+                return RedirectToPage("/Index");
+            }
+            returnUrl = returnUrl ?? Url.Content("~/");
+
+            var user = await _userManager.FindByEmailAsync(email);
+            if (user == null)
+            {
+                return NotFound($"Unable to load user with email '{email}'.");
+            }
+
+            Email = email;
+            DisplayConfirmAccountLink = false;
+            if (DisplayConfirmAccountLink)
+            {
+                var userId = await _userManager.GetUserIdAsync(user);
+                var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+                EmailConfirmationUrl = Url.Page(
+                    "/Account/ConfirmEmail",
+                    pageHandler: null,
+                    values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+                    protocol: Request.Scheme);
+            }
+
+            return Page();
+        }
+    }
+}

--- a/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
+
 
 namespace SIT.Controller.Areas.Identity.Pages.Account
 {
@@ -19,11 +21,14 @@ namespace SIT.Controller.Areas.Identity.Pages.Account
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly IEmailSender _sender;
+        private readonly bool _emailSenderEnabled;
 
-        public RegisterConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender sender)
+
+        public RegisterConfirmationModel(UserManager<IdentityUser> userManager, IEmailSender sender, IConfiguration configuration)
         {
             _userManager = userManager;
             _sender = sender;
+            _emailSenderEnabled = configuration.GetValue<bool>("EmailSender");
         }
 
         /// <summary>
@@ -59,7 +64,7 @@ namespace SIT.Controller.Areas.Identity.Pages.Account
             }
 
             Email = email;
-            DisplayConfirmAccountLink = false;
+            DisplayConfirmAccountLink = !_emailSenderEnabled;
             if (DisplayConfirmAccountLink)
             {
                 var userId = await _userManager.GetUserIdAsync(user);

--- a/Components/Account/EmailSender.cs
+++ b/Components/Account/EmailSender.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using RestSharp;
+using SIT.Controller.Areas.EmailSender;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SIT.Controller.Components.Account
+{
+    public class EmailSender : IEmailSender<IdentityUser>
+    {
+        private readonly MailgunOptions _options;
+        private readonly ILogger<EmailSender> _logger;
+
+        public EmailSender(IOptions<MailgunOptions> optionsAccessor, ILogger<EmailSender> logger)
+        {
+            _options = optionsAccessor.Value;
+            _logger = logger;
+        }
+
+        public Task SendConfirmationLinkAsync(IdentityUser user, string email, string confirmationLink)
+        {
+            return SendEmailAsync(email, "Confirm your email", $"Please confirm your account by <a href='{confirmationLink}'>clicking here</a>.");
+        }
+
+        public Task SendPasswordResetLinkAsync(IdentityUser user, string email, string resetLink)
+        {
+            return SendEmailAsync(email, "Reset your password", $"Please reset your password by <a href='{resetLink}'>clicking here</a>.");
+        }
+
+        public Task SendPasswordResetCodeAsync(IdentityUser user, string email, string resetCode)
+        {
+            return SendEmailAsync(email, "Reset your password", $"Please reset your password using the following code: {resetCode}");
+        }
+
+        public async Task SendEmailAsync(string toEmail, string subject, string message)
+        {
+            try
+            {
+                // Check if Mailgun credentials are configured
+                if (string.IsNullOrEmpty(_options.ApiKey) || string.IsNullOrEmpty(_options.Domain))
+                {
+                    throw new Exception("Mailgun ApiKey or Domain is not set");
+                }
+
+                // Log email preparation
+                _logger.LogInformation("Preparing to send email to {EmailAddress} with subject '{Subject}'", toEmail, subject);
+
+                // Create RestClient instance
+                var client = new RestClient($"https://api.eu.mailgun.net/v3/{_options.Domain}");
+
+                // Create RestRequest for sending message
+                var request = new RestRequest("messages", Method.Post);
+                request.AddParameter("from", "SIT Controller <noreply@mg.sit.publicvm.com>");
+                request.AddParameter("to", toEmail);
+                request.AddParameter("subject", subject);
+                request.AddParameter("html", message);  // Use 'html' instead of 'text' if sending HTML content
+
+                // Log Mailgun API Key and Domain
+                _logger.LogInformation("Mailgun API Key: {ApiKey}", _options.ApiKey);
+                _logger.LogInformation("Mailgun Domain: {Domain}", _options.Domain);
+
+                // Set Authorization header
+                request.AddHeader("Authorization", "Basic " + Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{_options.ApiKey}")));
+
+                // Log request details
+                _logger.LogInformation("Sending email request to Mailgun API");
+
+                // Execute the request asynchronously
+                var response = await client.ExecuteAsync(request);
+
+                // Log response details
+                _logger.LogInformation("Received response from Mailgun API");
+                _logger.LogInformation("Response Status Code: {StatusCode}", response.StatusCode);
+                _logger.LogInformation("Response Content: {Content}", response.Content);
+                _logger.LogInformation("Response Error Message: {ErrorMessage}", response.ErrorMessage);
+                _logger.LogInformation("Response Headers: {Headers}", response.Headers);
+
+                // Handle response status
+                if (response.IsSuccessful)
+                {
+                    _logger.LogInformation("Email to {EmailAddress} sent successfully!", toEmail);
+                }
+                else
+                {
+                    _logger.LogError("Failed to send email to {EmailAddress}. Status: {Status}, Error: {Error}, Content: {Content}", toEmail, response.StatusCode, response.ErrorMessage, response.Content);
+                    throw new Exception($"Failed to send email: {response.ErrorMessage}");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception occurred while sending email to {EmailAddress}", toEmail);
+                throw; // Re-throw the exception to propagate it further if needed
+            }
+        }
+    }
+}

--- a/Components/Account/IEmailSender.cs
+++ b/Components/Account/IEmailSender.cs
@@ -1,0 +1,9 @@
+﻿namespace SIT.Controller.Components.Account
+{
+    public interface IEmailSender<TUser>
+    {
+        Task SendConfirmationLinkAsync(TUser user, string email, string confirmationLink);
+        Task SendPasswordResetLinkAsync(TUser user, string email, string resetLink);
+        Task SendPasswordResetCodeAsync(TUser user, string email, string resetCode);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -6,11 +6,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using SIT.Controller.Components.Account;
 using SIT.Controller.Areas.Identity;
 using SIT.Controller.Controllers;
 using SIT.Controller.Data;
 using System;
 using System.IO;
+using SIT.Controller.Areas.EmailSender;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -18,14 +20,21 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.SetBasePath(Directory.GetCurrentDirectory());
 builder.Configuration.AddJsonFile("config.json", optional: false, reloadOnChange: true);
 
+
 // Add services to the container
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlite(connectionString));
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+
 builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
     .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>();
+builder.Services.Configure<MailgunOptions>(builder.Configuration.GetSection("MailgunOptions"));
+builder.Services.AddTransient<IEmailSender<IdentityUser>, EmailSender>();
+
+
 builder.Services.AddRazorPages();
 builder.Services.AddBlazorBootstrap();
 builder.Services.AddServerSideBlazor();
@@ -34,6 +43,9 @@ builder.Services.AddSingleton<ServerManager>();
 builder.Services.AddSingleton<WeatherConfigService>();
 builder.Services.AddSingleton<RegistrationStateService>();
 builder.Services.AddSingleton<GameProfileService>();
+builder.Services.AddSingleton<IEmailSender<IdentityUser>, EmailSender>();
+
+
 
 builder.Services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 builder.Services.AddScoped<ILocalhostService, LocalhostService>();

--- a/SIT.Controller.csproj
+++ b/SIT.Controller.csproj
@@ -25,7 +25,6 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<Authors>Mihai</Authors>
 		<PackageProjectUrl>https://github.com/mihaicm93/SIT.Controlle</PackageProjectUrl>
-		<NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -38,6 +37,7 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.18" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.12" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.18" />
+		<PackageReference Include="RestSharp" Version="111.3.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Shared/NavMenu.razor.css
+++ b/Shared/NavMenu.razor.css
@@ -6,6 +6,7 @@
     backdrop-filter: blur(8px);
     background: rgba(25, 25, 25, 0.2);
     padding-bottom: 1rem;
+    width: 212px;
 }
 
     .sidebar::before {
@@ -37,11 +38,11 @@
 
 .navbar-brand {
     font-size: 1.1rem;
-    text-decoration: none; /* Ensure no underline */
+    text-decoration: none;
     color: white;
-    margin-right: 1rem; /* Adjust margin as needed */
-    display: flex; /* Ensure flex layout for proper alignment */
-    align-items: center; /* Center vertically */
+    margin-right: 1rem;
+    display: flex;
+    align-items: center;
 }
 
 .oi {
@@ -103,6 +104,7 @@
         overflow-y: auto;
         max-height: calc(100vh - 3.5rem) !important;
         position:relative;
+        width:auto;
     }
 
     .flex-column {

--- a/appsettings.json
+++ b/appsettings.json
@@ -12,5 +12,6 @@
     "ApiKey": "",
     "Domain": ""
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "EmailSender": false
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,5 +8,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "MailgunOptions": {
+    "ApiKey": "",
+    "Domain": ""
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
This PR introduces the initial implementation of the Email Sender functionality using the Mailgun API. It includes setting up the `EmailSender` class and configuring email sending options in `appsettings.json`.

1. **EmailSender Implementation**:
   - Added `EmailSender` class implementing `IEmailSender` for sending emails via Mailgun API.
   - Methods added for sending confirmation links, password reset links, and reset codes.
   - Enhanced logging for email preparation, sending, and response handling.

2. **Configuration Settings**:
   - Introduced `MailgunOptions` in `appsettings.json` to configure Mailgun API settings.
   - Default setting (`EmailSender: false`) ensures the app functions without immediate Mailgun setup.
   - Enabling email sending requires valid `ApiKey` and `Domain` settings in `MailgunOptions`.
   
   
   #### Detailed Configuration
- **appsettings.json**:
  ```json
  {
    "MailgunOptions": {
      "ApiKey": "", // Your Mailgun API Key
      "Domain": "" // Your Mailgun Domain
    }
    "EmailSender": false, // Set to true to enable email sending
  }